### PR TITLE
Add simple WPF activation viewer

### DIFF
--- a/Kraken/LicenseInfo.cs
+++ b/Kraken/LicenseInfo.cs
@@ -1,0 +1,7 @@
+namespace Kraken;
+
+public class LicenseInfo
+{
+    public string Name { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+}

--- a/Kraken/MainWindow.xaml
+++ b/Kraken/MainWindow.xaml
@@ -7,6 +7,6 @@
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
     <Grid>
-
+        <DataGrid x:Name="LicensesGrid" AutoGenerateColumns="True"/>
     </Grid>
 </Window>

--- a/Kraken/MainWindow.xaml.cs
+++ b/Kraken/MainWindow.xaml.cs
@@ -1,24 +1,41 @@
-﻿using System.Text;
+using System.Collections.ObjectModel;
+using System.Management;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
-namespace Kraken
+namespace Kraken;
+
+/// <summary>
+/// Interaction logic for MainWindow.xaml
+/// </summary>
+public partial class MainWindow : Window
 {
-    /// <summary>
-    /// Interaction logic for MainWindow.xaml
-    /// </summary>
-    public partial class MainWindow : Window
+    private ObservableCollection<LicenseInfo> Licenses { get; } = new();
+
+    public MainWindow()
     {
-        public MainWindow()
+        InitializeComponent();
+        LicensesGrid.ItemsSource = Licenses;
+        LoadLicenses();
+    }
+
+    private void LoadLicenses()
+    {
+        using var searcher = new ManagementObjectSearcher("SELECT Name, LicenseStatus FROM SoftwareLicensingProduct WHERE PartialProductKey IS NOT NULL");
+        foreach (var obj in searcher.Get())
         {
-            InitializeComponent();
+            var name = obj["Name"]?.ToString() ?? string.Empty;
+            var statusCode = obj["LicenseStatus"] != null ? Convert.ToInt32(obj["LicenseStatus"]) : 0;
+            var status = statusCode switch
+            {
+                0 => "Unlicensed",
+                1 => "Licensed",
+                2 => "Grace",
+                3 => "Notification",
+                4 => "Expired",
+                5 => "Extended Grace",
+                _ => "Unknown"
+            };
+            Licenses.Add(new LicenseInfo { Name = name, Status = status });
         }
     }
 }


### PR DESCRIPTION
## Summary
- Display Windows license information in a WPF DataGrid
- Query licensing data via WMI and present name and status

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02bef1ed88326b4140083d600b07a