### PR TITLE
Expand license status retrieval in WPF app

### DIFF
--- a/Kraken/LicenseInfo.cs
+++ b/Kraken/LicenseInfo.cs
@@ -1,7 +1,15 @@
+using System;
+
 namespace Kraken;
 
 public class LicenseInfo
 {
+    public string Application { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string ActivationId { get; set; } = string.Empty;
+    public string PartialProductKey { get; set; } = string.Empty;
     public string Status { get; set; } = string.Empty;
+    public int GraceMinutes { get; set; }
+    public DateTime? EvaluationEndDate { get; set; }
 }


### PR DESCRIPTION
## Summary
- Display detailed license data for Windows and Office products
- Show activation ID, partial key, description, grace period and evaluation date

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b02f6debe483269ca8325e35dc65c3