### PR TITLE
Add ActivationInspector core and UI scaffolding

### DIFF
--- a/ActivationInspector.Core/ActivationInspector.Core.csproj
+++ b/ActivationInspector.Core/ActivationInspector.Core.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Libraries for registry and WMI access -->
+    <PackageReference Include="System.Management" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/ActivationInspector.Core/Export/ExportService.cs
+++ b/ActivationInspector.Core/Export/ExportService.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using ActivationInspector.Core.Models;
+
+namespace ActivationInspector.Core.Export;
+
+/// <summary>
+/// Handles simple data export scenarios (JSON/TXT/CSV). Only JSON is implemented
+/// for brevity, the other formats can be added later following the same idea.
+/// </summary>
+public static class ExportService
+{
+    public static Task<string> ExportJsonAsync(IEnumerable<WindowsLicenseDto> windowsLicenses)
+    {
+        return Task.Run(() =>
+        {
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true
+            };
+            return JsonSerializer.Serialize(windowsLicenses, options);
+        });
+    }
+}

--- a/ActivationInspector.Core/Interop/ClipcNative.cs
+++ b/ActivationInspector.Core/Interop/ClipcNative.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace ActivationInspector.Core.Interop;
+
+internal static class ClipcNative
+{
+    [DllImport("Clipc.dll", SetLastError = true)]
+    internal static extern int ClipGetSubscriptionStatus(out IntPtr pStatus);
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SubStatus
+    {
+        public uint dwEnabled;
+        public uint dwSku;
+        public uint dwState;
+    }
+}

--- a/ActivationInspector.Core/Interop/SppNative.cs
+++ b/ActivationInspector.Core/Interop/SppNative.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace ActivationInspector.Core.Interop;
+
+internal static class SppNative
+{
+    [DllImport("sppc.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    internal static extern int SLOpen(out IntPtr hSLC);
+
+    [DllImport("sppc.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    internal static extern int SLClose(IntPtr hSLC);
+
+    [DllImport("sppc.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    internal static extern int SLGetSLIDList(
+        IntPtr hSLC, uint eQuery, ref Guid appId, uint flags,
+        ref uint pcReturnIds, ref IntPtr pReturnIds);
+
+    [DllImport("sppc.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    internal static extern int SLGetLicensingStatusInformation(
+        IntPtr hSLC, ref Guid appId, ref Guid skuId, IntPtr pInfoQuery,
+        ref uint pcStatus, ref IntPtr ppStatus);
+
+    [DllImport("sppc.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    internal static extern int SLGetPKeyInformation(
+        IntPtr hSLC, ref Guid pkeyId, string value,
+        ref uint pType, ref uint pcbValue, ref IntPtr ppbValue);
+
+    [DllImport("sppc.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    internal static extern int SLGetProductSkuInformation(
+        IntPtr hSLC, ref Guid skuId, string value,
+        ref uint pType, ref uint pcbValue, ref IntPtr ppbValue);
+
+    [DllImport("sppc.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    internal static extern int SLGetServiceInformation(
+        IntPtr hSLC, string value, ref uint pType,
+        ref uint pcbValue, ref IntPtr ppbValue);
+
+    [DllImport("slc.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    internal static extern int SLGetWindowsInformation(
+        string value, ref uint pType, ref uint pcbValue, ref IntPtr ppbValue);
+
+    [DllImport("slc.dll", SetLastError = true)]
+    internal static extern int SLGetWindowsInformationDWORD(string value, ref uint valueOut);
+
+    [DllImport("slc.dll", SetLastError = true)]
+    internal static extern int SLIsWindowsGenuineLocal(ref uint dwGenuine);
+
+    [DllImport("sppc.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    internal static extern int SLGenerateOfflineInstallationId(
+        IntPtr hSLC, ref Guid skuId, ref IntPtr pwszInstallationId);
+}

--- a/ActivationInspector.Core/Licensing/LicensingService.cs
+++ b/ActivationInspector.Core/Licensing/LicensingService.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ActivationInspector.Core.Models;
+
+namespace ActivationInspector.Core.Licensing;
+
+/// <summary>
+/// Facade that exposes simplified access points for retrieving licensing
+/// information. Additional providers (Office, diagnostics, etc.) can be added
+/// following the same pattern.
+/// </summary>
+public class LicensingService
+{
+    private readonly WindowsLicensingProvider _windowsProvider = new();
+
+    public Task<IReadOnlyList<WindowsLicenseDto>> GetWindowsLicensesAsync(CancellationToken token = default)
+        => _windowsProvider.GetLicensesAsync(token);
+}

--- a/ActivationInspector.Core/Licensing/WindowsLicensingProvider.cs
+++ b/ActivationInspector.Core/Licensing/WindowsLicensingProvider.cs
@@ -1,0 +1,53 @@
+using ActivationInspector.Core.Interop;
+using ActivationInspector.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ActivationInspector.Core.Licensing;
+
+/// <summary>
+/// Provides a minimal wrapper around the native Software Licensing API used by Windows.
+/// The real script exposes a vast amount of information; here we only query whether the
+/// current installation is considered genuine by the local licensing service.
+/// </summary>
+public class WindowsLicensingProvider
+{
+    public Task<IReadOnlyList<WindowsLicenseDto>> GetLicensesAsync(CancellationToken token)
+    {
+        return Task.Run(() =>
+        {
+            var list = new List<WindowsLicenseDto>();
+            try
+            {
+                uint genuine = 0;
+                int hr = SppNative.SLIsWindowsGenuineLocal(ref genuine);
+                var dto = new WindowsLicenseDto
+                {
+                    Name = "Windows",
+                    LicenseStatus = hr == 0 ? (genuine == 1 ? "Licensed" : "Unlicensed") : $"HRESULT 0x{hr:X8}"
+                };
+                list.Add(dto);
+            }
+            catch (DllNotFoundException)
+            {
+                list.Add(new WindowsLicenseDto
+                {
+                    Name = "Windows",
+                    LicenseStatus = "Licensing APIs not available"
+                });
+            }
+            catch (Exception ex)
+            {
+                list.Add(new WindowsLicenseDto
+                {
+                    Name = "Windows",
+                    LicenseStatus = ex.Message
+                });
+            }
+            return (IReadOnlyList<WindowsLicenseDto>)list;
+        }, token);
+    }
+}

--- a/ActivationInspector.Core/Models/WindowsLicenseDto.cs
+++ b/ActivationInspector.Core/Models/WindowsLicenseDto.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace ActivationInspector.Core.Models;
+
+/// <summary>
+/// Basic DTO representing a Windows license instance.
+/// The structure intentionally mirrors the data extracted from the
+/// Check-Activation-Status script but is simplified for demonstration purposes.
+/// </summary>
+public class WindowsLicenseDto
+{
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public Guid ActivationId { get; set; }
+    public string? LicenseStatus { get; set; }
+    public int GraceMinutes { get; set; }
+    public DateTime? GraceEndsAt { get; set; }
+    public string? PartialProductKey { get; set; }
+    public string? Channel { get; set; }
+    public string? DigitalPid { get; set; }
+    public string? DigitalPid2 { get; set; }
+    public DateTime? EvaluationEndDate { get; set; }
+    public bool PhoneActivatable { get; set; }
+    public string[] Messages { get; set; } = Array.Empty<string>();
+}

--- a/ActivationInspector.Tests/ActivationInspector.Tests.csproj
+++ b/ActivationInspector.Tests/ActivationInspector.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ActivationInspector.Core\ActivationInspector.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ActivationInspector.Tests/ExportServiceTests.cs
+++ b/ActivationInspector.Tests/ExportServiceTests.cs
@@ -1,0 +1,26 @@
+using ActivationInspector.Core.Export;
+using ActivationInspector.Core.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace ActivationInspector.Tests;
+
+[TestClass]
+public class ExportServiceTests
+{
+    [TestMethod]
+    public async Task ExportJsonProducesExpectedStructure()
+    {
+        var licenses = new List<WindowsLicenseDto>
+        {
+            new() { Name = "Windows", LicenseStatus = "Licensed" }
+        };
+
+        string json = await ExportService.ExportJsonAsync(licenses);
+        var doc = JsonDocument.Parse(json);
+        Assert.AreEqual("Windows", doc.RootElement[0].GetProperty("Name").GetString());
+        Assert.AreEqual("Licensed", doc.RootElement[0].GetProperty("LicenseStatus").GetString());
+    }
+}

--- a/ActivationInspector.Tests/GlobalUsings.cs
+++ b/ActivationInspector.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/ActivationInspector.UI/ActivationInspector.UI.csproj
+++ b/ActivationInspector.UI/ActivationInspector.UI.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\\ActivationInspector.Core\\ActivationInspector.Core.csproj" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
+  </ItemGroup>
+</Project>

--- a/ActivationInspector.UI/App.xaml
+++ b/ActivationInspector.UI/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="ActivationInspector.UI.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:ActivationInspector.UI"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/ActivationInspector.UI/App.xaml.cs
+++ b/ActivationInspector.UI/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace ActivationInspector.UI;
+
+public partial class App : Application
+{
+}

--- a/ActivationInspector.UI/MainWindow.xaml
+++ b/ActivationInspector.UI/MainWindow.xaml
@@ -1,0 +1,24 @@
+<Window x:Class="ActivationInspector.UI.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:ActivationInspector.UI.ViewModels"
+        mc:Ignorable="d"
+        Title="Activation Inspector" Height="450" Width="800">
+    <Window.DataContext>
+        <vm:MainViewModel />
+    </Window.DataContext>
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5">
+            <Button Content="Refresh" Command="{Binding RefreshCommand}" Margin="2"/>
+            <Button Content="Export JSON" Command="{Binding ExportJsonCommand}" Margin="2"/>
+            <CheckBox Content="All" IsChecked="{Binding AllFlag}" Margin="10,0"/>
+            <CheckBox Content="Dlv" IsChecked="{Binding DlvFlag}" Margin="10,0"/>
+            <CheckBox Content="IID" IsChecked="{Binding IidFlag}" Margin="10,0"/>
+            <CheckBox Content="NoClear" IsChecked="{Binding NoClearFlag}" Margin="10,0"/>
+        </StackPanel>
+        <DataGrid ItemsSource="{Binding WindowsLicenses}" AutoGenerateColumns="True" Margin="5"/>
+        <TextBox DockPanel.Dock="Bottom" Text="{Binding LogText}" IsReadOnly="True" Height="100" Margin="5" AcceptsReturn="True" VerticalScrollBarVisibility="Auto"/>
+    </DockPanel>
+</Window>

--- a/ActivationInspector.UI/MainWindow.xaml.cs
+++ b/ActivationInspector.UI/MainWindow.xaml.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace ActivationInspector.UI;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/ActivationInspector.UI/ViewModels/MainViewModel.cs
+++ b/ActivationInspector.UI/ViewModels/MainViewModel.cs
@@ -1,0 +1,59 @@
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using ActivationInspector.Core.Export;
+using ActivationInspector.Core.Licensing;
+using ActivationInspector.Core.Models;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace ActivationInspector.UI.ViewModels;
+
+public partial class MainViewModel : ObservableObject
+{
+    private readonly LicensingService _licensingService = new();
+
+    public ObservableCollection<WindowsLicenseDto> WindowsLicenses { get; } = new();
+
+    [ObservableProperty]
+    private bool allFlag;
+
+    [ObservableProperty]
+    private bool dlvFlag;
+
+    [ObservableProperty]
+    private bool iidFlag;
+
+    [ObservableProperty]
+    private bool noClearFlag;
+
+    [ObservableProperty]
+    private string logText = string.Empty;
+
+    public IAsyncRelayCommand RefreshCommand { get; }
+    public IAsyncRelayCommand ExportJsonCommand { get; }
+
+    public MainViewModel()
+    {
+        RefreshCommand = new AsyncRelayCommand(RefreshAsync);
+        ExportJsonCommand = new AsyncRelayCommand(ExportJsonAsync);
+    }
+
+    private async Task RefreshAsync()
+    {
+        var licenses = await _licensingService.GetWindowsLicensesAsync();
+        WindowsLicenses.Clear();
+        foreach (var l in licenses)
+        {
+            WindowsLicenses.Add(l);
+        }
+        if (!NoClearFlag)
+            LogText = string.Empty;
+        LogText += $"Scanned {licenses.Count} license(s)\n";
+    }
+
+    private async Task ExportJsonAsync()
+    {
+        var json = await ExportService.ExportJsonAsync(WindowsLicenses);
+        LogText += $"Exported JSON length: {json.Length}\n";
+    }
+}

--- a/ActivationInspector.sln
+++ b/ActivationInspector.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActivationInspector.Core", "ActivationInspector.Core\ActivationInspector.Core.csproj", "{EBAEA971-5DF0-4FCA-852F-6E15284F73D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActivationInspector.UI", "ActivationInspector.UI\ActivationInspector.UI.csproj", "{24C7EE09-66A9-4630-8647-3A52201040B3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActivationInspector.Tests", "ActivationInspector.Tests\ActivationInspector.Tests.csproj", "{5755ED07-2DCE-489A-A57D-876C96FEAB2B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{24C7EE09-66A9-4630-8647-3A52201040B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24C7EE09-66A9-4630-8647-3A52201040B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24C7EE09-66A9-4630-8647-3A52201040B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24C7EE09-66A9-4630-8647-3A52201040B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EBAEA971-5DF0-4FCA-852F-6E15284F73D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EBAEA971-5DF0-4FCA-852F-6E15284F73D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EBAEA971-5DF0-4FCA-852F-6E15284F73D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EBAEA971-5DF0-4FCA-852F-6E15284F73D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5755ED07-2DCE-489A-A57D-876C96FEAB2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5755ED07-2DCE-489A-A57D-876C96FEAB2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5755ED07-2DCE-489A-A57D-876C96FEAB2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5755ED07-2DCE-489A-A57D-876C96FEAB2B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- scaffold ActivationInspector solution with core, WPF UI and tests
- provide Windows licensing interop and minimal licensing provider
- add export service and MVVM-based UI

## Testing
- `dotnet test ActivationInspector.Tests/ActivationInspector.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b0334d80308326a4bddfa1edc09f2c