### PR TITLE
Display Windows system information

### DIFF
--- a/Kraken/MainWindow.xaml
+++ b/Kraken/MainWindow.xaml
@@ -7,6 +7,11 @@
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
     <Grid>
-        <DataGrid x:Name="LicensesGrid" AutoGenerateColumns="True"/>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <TextBlock x:Name="SystemInfoText" Margin="5" />
+        <DataGrid x:Name="LicensesGrid" AutoGenerateColumns="True" Grid.Row="1" />
     </Grid>
 </Window>

--- a/Kraken/MainWindow.xaml.cs
+++ b/Kraken/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Management;
+using System.Runtime.InteropServices;
 using System.Windows;
 
 namespace Kraken;
@@ -16,7 +17,30 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         LicensesGrid.ItemsSource = Licenses;
+        DisplaySystemInfo();
         LoadLicenses();
+    }
+
+    private void DisplaySystemInfo()
+    {
+        try
+        {
+            using var searcher = new ManagementObjectSearcher(
+                "SELECT Caption, Version, BuildNumber, OSArchitecture FROM Win32_OperatingSystem");
+            foreach (var obj in searcher.Get())
+            {
+                var caption = obj["Caption"]?.ToString()?.Trim() ?? "Windows";
+                var version = obj["Version"]?.ToString() ?? string.Empty;
+                var build = obj["BuildNumber"]?.ToString() ?? string.Empty;
+                var arch = obj["OSArchitecture"]?.ToString() ?? RuntimeInformation.OSArchitecture.ToString();
+                SystemInfoText.Text = $"{caption} Version {version} (Build {build}, {arch})";
+                break;
+            }
+        }
+        catch (ManagementException)
+        {
+            SystemInfoText.Text = $"{RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})";
+        }
     }
 
     private void LoadLicenses()


### PR DESCRIPTION
## Summary
- show Windows version, build and architecture at top of main window
- retrieve OS details through WMI to display them in UI

## Testing
- `dotnet build Kraken.sln` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b069e039fc8326a4e2c8e821ba2c95