### PR TITLE
Add offline installation ID retrieval

### DIFF
--- a/Kraken/LicenseInfo.cs
+++ b/Kraken/LicenseInfo.cs
@@ -12,4 +12,5 @@ public class LicenseInfo
     public string Status { get; set; } = string.Empty;
     public int GraceMinutes { get; set; }
     public DateTime? EvaluationEndDate { get; set; }
+    public string InstallationId { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Summary
- expose InstallationId on license model
- query SPP API for offline installation IDs when loading licenses

## Testing
- `dotnet build Kraken.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b63c4b7083269c484e30deddecfc