### PR TITLE
Add SPP license viewer WPF app

### DIFF
--- a/Kraken/LicenseService.cs
+++ b/Kraken/LicenseService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Management;
+using Microsoft.Win32;
 
 namespace Kraken;
 
@@ -28,8 +29,16 @@ public static class LicenseService
             summary.WindowsLicense = GetWindowsLicense(null);
             summary.OfficeLicenses = GetOfficeLicenses(null);
         }
-
-        // Other sections are not implemented in this minimal sample and will remain null.
+        summary.KmsServer = GetKmsServerInfo();
+        summary.KmsClient = GetKmsClientInfo();
+        summary.Subscription = GetSubscriptionInfo();
+        summary.VNext = GetVNextInfo();
+        summary.AdActivation = GetAdActivationInfo();
+        summary.VmActivation = GetVmActivationInfo();
+        if (summary.WindowsLicense != null)
+        {
+            summary.WindowsLicense.IsDigitalLicense = IsDigitalLicense();
+        }
         return summary;
     }
 
@@ -42,7 +51,7 @@ public static class LicenseService
         try
         {
             using var searcher = new ManagementObjectSearcher(
-                "SELECT Name, Description, ID, PartialProductKey, LicenseStatus, GracePeriodRemaining, EvaluationEndDate FROM SoftwareLicensingProduct WHERE PartialProductKey IS NOT NULL");
+                "SELECT Name, Description, ID, PartialProductKey, LicenseStatus, GracePeriodRemaining, EvaluationEndDate, ProductKeyChannel FROM SoftwareLicensingProduct WHERE PartialProductKey IS NOT NULL");
             foreach (var obj in searcher.Get())
             {
                 var info = new WindowsLicenseInfo
@@ -52,7 +61,9 @@ public static class LicenseService
                     PartialProductKey = obj["PartialProductKey"]?.ToString() ?? string.Empty,
                     Status = LicenseStatusToString(obj["LicenseStatus"]),
                     GraceMinutes = obj["GracePeriodRemaining"] != null ? Convert.ToInt32(obj["GracePeriodRemaining"]) : 0,
-                    Expiration = ParseDate(obj["EvaluationEndDate"])
+                    Expiration = ParseDate(obj["EvaluationEndDate"]),
+                    Channel = obj["ProductKeyChannel"]?.ToString() ?? string.Empty,
+                    EvaluationEndDate = ParseDate(obj["EvaluationEndDate"])
                 };
                 return info;
             }
@@ -73,7 +84,7 @@ public static class LicenseService
         var list = new List<OfficeLicenseInfo>();
         try
         {
-            const string query = "SELECT Name, Description, ID, PartialProductKey, LicenseStatus, GracePeriodRemaining, EvaluationEndDate FROM OfficeSoftwareProtectionProduct WHERE PartialProductKey IS NOT NULL";
+            const string query = "SELECT Name, Description, ID, PartialProductKey, LicenseStatus, GracePeriodRemaining, EvaluationEndDate, ProductKeyChannel FROM OfficeSoftwareProtectionProduct WHERE PartialProductKey IS NOT NULL";
             using var searcher = new ManagementObjectSearcher(query);
             foreach (var obj in searcher.Get())
             {
@@ -86,7 +97,8 @@ public static class LicenseService
                     PartialProductKey = obj["PartialProductKey"]?.ToString() ?? string.Empty,
                     Status = LicenseStatusToString(obj["LicenseStatus"]),
                     GraceMinutes = obj["GracePeriodRemaining"] != null ? Convert.ToInt32(obj["GracePeriodRemaining"]) : 0,
-                    Expiration = ParseDate(obj["EvaluationEndDate"])
+                    Expiration = ParseDate(obj["EvaluationEndDate"]),
+                    Channel = obj["ProductKeyChannel"]?.ToString() ?? string.Empty
                 };
                 list.Add(lic);
             }
@@ -96,6 +108,216 @@ public static class LicenseService
             // ignore
         }
         return list;
+    }
+
+    /// <summary>
+    /// Retrieves information about the local KMS server.
+    /// </summary>
+    public static KmsServerInfo? GetKmsServerInfo()
+    {
+        try
+        {
+            using var searcher = new ManagementObjectSearcher(
+                "SELECT KeyManagementServiceCurrentCount, KeyManagementServiceTotalRequests, KeyManagementServiceFailedRequests, KeyManagementServiceMachineName, KeyManagementServicePort, KeyManagementServiceMachineIpAddress FROM SoftwareLicensingService");
+            foreach (var obj in searcher.Get())
+            {
+                return new KmsServerInfo
+                {
+                    CurrentClients = Convert.ToInt32(obj["KeyManagementServiceCurrentCount"] ?? 0),
+                    TotalRequests = Convert.ToInt32(obj["KeyManagementServiceTotalRequests"] ?? 0),
+                    FailedRequests = Convert.ToInt32(obj["KeyManagementServiceFailedRequests"] ?? 0),
+                    Name = obj["KeyManagementServiceMachineName"]?.ToString() ?? string.Empty,
+                    Port = obj["KeyManagementServicePort"] != null ? Convert.ToInt32(obj["KeyManagementServicePort"]) : 0,
+                    IPAddress = obj["KeyManagementServiceMachineIpAddress"]?.ToString() ?? string.Empty
+                };
+            }
+        }
+        catch
+        {
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Retrieves information about the KMS client.
+    /// </summary>
+    public static KmsClientInfo? GetKmsClientInfo()
+    {
+        try
+        {
+            using var searcher = new ManagementObjectSearcher(
+                "SELECT ClientMachineID, KeyManagementServiceMachineName, KeyManagementServicePort, DiscoveredKeyManagementServiceMachineName, DiscoveredKeyManagementServiceMachinePort, DiscoveredKeyManagementServiceMachineIpAddress, VLActivationInterval FROM SoftwareLicensingService");
+            foreach (var obj in searcher.Get())
+            {
+                return new KmsClientInfo
+                {
+                    ClientPid = obj["ClientMachineID"]?.ToString() ?? string.Empty,
+                    ServerName = obj["KeyManagementServiceMachineName"]?.ToString() ?? string.Empty,
+                    ServerPort = obj["KeyManagementServicePort"] != null ? Convert.ToInt32(obj["KeyManagementServicePort"]) : 0,
+                    DiscoveredName = obj["DiscoveredKeyManagementServiceMachineName"]?.ToString() ?? string.Empty,
+                    DiscoveredPort = obj["DiscoveredKeyManagementServiceMachinePort"] != null ? Convert.ToInt32(obj["DiscoveredKeyManagementServiceMachinePort"]) : 0,
+                    DiscoveredIP = obj["DiscoveredKeyManagementServiceMachineIpAddress"]?.ToString() ?? string.Empty,
+                    RenewalInterval = obj["VLActivationInterval"] != null ? Convert.ToInt32(obj["VLActivationInterval"]) : 0
+                };
+            }
+        }
+        catch
+        {
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Checks whether the system has a digital licence.
+    /// </summary>
+    public static bool IsDigitalLicense()
+    {
+        try
+        {
+            var type = Type.GetTypeFromProgID("EditionUpgradeManagerObj.EditionUpgradeManager");
+            if (type == null)
+                return false;
+            dynamic obj = Activator.CreateInstance(type);
+            obj?.AcquireModernLicenseForWindows();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets subscription information, if available.
+    /// </summary>
+    public static SubscriptionInfo? GetSubscriptionInfo()
+    {
+        try
+        {
+            if (SppApi.TryGetSubscriptionStatus(out var status))
+            {
+                return new SubscriptionInfo
+                {
+                    Enabled = status.dwEnabled != 0,
+                    Sku = status.dwSku,
+                    State = status.dwState
+                };
+            }
+        }
+        catch
+        {
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Retrieves vNext diagnostic information from the registry.
+    /// </summary>
+    public static VNextInfo? GetVNextInfo()
+    {
+        try
+        {
+            var info = new VNextInfo();
+            using var cfgKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Office\ClickToRun\Configuration");
+            if (cfgKey != null)
+            {
+                info.SharedComputerLicensing = Convert.ToInt32(cfgKey.GetValue("SharedComputerLicensing", 0)) != 0;
+            }
+
+            using var modeKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Office\ClickToRun\Scenario");
+            if (modeKey != null)
+            {
+                foreach (var name in modeKey.GetValueNames())
+                {
+                    info.ModePerProductReleaseId[name] = modeKey.GetValue(name)?.ToString() ?? string.Empty;
+                }
+            }
+
+            using var licKey = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Office\Licenses");
+            if (licKey != null)
+            {
+                foreach (var sub in licKey.GetSubKeyNames())
+                {
+                    info.Licenses.Add(sub);
+                }
+            }
+            return info;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Retrieves Active Directory activation information.
+    /// </summary>
+    public static AdActivationInfo? GetAdActivationInfo()
+    {
+        try
+        {
+            using var searcher = new ManagementObjectSearcher(
+                "SELECT ADActivationObjectName, ADActivationObjectDN, KeyManagementServiceProductKeyID, KeyManagementServiceSkuID FROM SoftwareLicensingService");
+            foreach (var obj in searcher.Get())
+            {
+                return new AdActivationInfo
+                {
+                    ObjectName = obj["ADActivationObjectName"]?.ToString() ?? string.Empty,
+                    ObjectDN = obj["ADActivationObjectDN"]?.ToString() ?? string.Empty,
+                    CsvlkPid = obj["KeyManagementServiceProductKeyID"]?.ToString() ?? string.Empty,
+                    CsvlkSkuId = obj["KeyManagementServiceSkuID"]?.ToString() ?? string.Empty
+                };
+            }
+        }
+        catch
+        {
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Retrieves VM activation information.
+    /// </summary>
+    public static VmActivationInfo? GetVmActivationInfo()
+    {
+        try
+        {
+            using var searcher = new ManagementObjectSearcher(
+                "SELECT InheritedActivationID, VirtualizationHostMachineName, VirtualizationHostDigitalPid2, VirtualizationActivationTime FROM SoftwareLicensingService");
+            foreach (var obj in searcher.Get())
+            {
+                return new VmActivationInfo
+                {
+                    InheritedActivationId = obj["InheritedActivationID"]?.ToString() ?? string.Empty,
+                    HostMachineName = obj["VirtualizationHostMachineName"]?.ToString() ?? string.Empty,
+                    HostDigitalPid2 = obj["VirtualizationHostDigitalPid2"]?.ToString() ?? string.Empty,
+                    ActivationTime = ParseDate(obj["VirtualizationActivationTime"])
+                };
+            }
+        }
+        catch
+        {
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Determines if shared computer licensing is enabled for Office.
+    /// </summary>
+    public static bool IsSharedComputerLicensingEnabled()
+    {
+        try
+        {
+            using var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Office\ClickToRun\Configuration");
+            if (key != null)
+            {
+                return Convert.ToInt32(key.GetValue("SharedComputerLicensing", 0)) != 0;
+            }
+        }
+        catch
+        {
+        }
+        return false;
     }
 
     private static string LicenseStatusToString(object? statusObj)

--- a/Kraken/MainWindow.xaml
+++ b/Kraken/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="Kraken.MainWindow"
+<Window x:Class="Kraken.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -9,9 +9,66 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock x:Name="SystemInfoText" Margin="5" />
-        <DataGrid x:Name="LicensesGrid" AutoGenerateColumns="True" Grid.Row="1" />
+        <TextBlock Margin="5" Text="{Binding SystemInfo}" />
+        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="5">
+            <Button Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,5,0" />
+            <Button Content="Save JSON" Command="{Binding SaveJsonCommand}" />
+        </StackPanel>
+        <TabControl Grid.Row="2">
+            <TabItem Header="Windows">
+                <DataGrid ItemsSource="{Binding WindowsLicenseList}" AutoGenerateColumns="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Product" Binding="{Binding ProductName}" />
+                        <DataGridTextColumn Header="Description" Binding="{Binding Description}" />
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" />
+                        <DataGridTextColumn Header="Grace" Binding="{Binding GraceMinutes}" />
+                        <DataGridTextColumn Header="Expiration" Binding="{Binding Expiration}" />
+                        <DataGridTextColumn Header="ProductKey" Binding="{Binding PartialProductKey}" />
+                        <DataGridTextColumn Header="Channel" Binding="{Binding Channel}" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+            <TabItem Header="Office">
+                <DataGrid ItemsSource="{Binding Summary.OfficeLicenses}" AutoGenerateColumns="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="SLID" Binding="{Binding SLID}" />
+                        <DataGridTextColumn Header="Product" Binding="{Binding ProductName}" />
+                        <DataGridTextColumn Header="Status" Binding="{Binding Status}" />
+                        <DataGridTextColumn Header="Grace" Binding="{Binding GraceMinutes}" />
+                        <DataGridTextColumn Header="Expiration" Binding="{Binding Expiration}" />
+                        <DataGridTextColumn Header="ProductKey" Binding="{Binding PartialProductKey}" />
+                        <DataGridTextColumn Header="Channel" Binding="{Binding Channel}" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+            <TabItem Header="KMS Server">
+                <DataGrid ItemsSource="{Binding KmsServerList}" AutoGenerateColumns="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" />
+                        <DataGridTextColumn Header="Port" Binding="{Binding Port}" />
+                        <DataGridTextColumn Header="IP" Binding="{Binding IPAddress}" />
+                        <DataGridTextColumn Header="Current" Binding="{Binding CurrentClients}" />
+                        <DataGridTextColumn Header="Total" Binding="{Binding TotalRequests}" />
+                        <DataGridTextColumn Header="Failed" Binding="{Binding FailedRequests}" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+            <TabItem Header="KMS Client">
+                <DataGrid ItemsSource="{Binding KmsClientList}" AutoGenerateColumns="False">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Client PID" Binding="{Binding ClientPid}" />
+                        <DataGridTextColumn Header="Server" Binding="{Binding ServerName}" />
+                        <DataGridTextColumn Header="Server Port" Binding="{Binding ServerPort}" />
+                        <DataGridTextColumn Header="Discovered Name" Binding="{Binding DiscoveredName}" />
+                        <DataGridTextColumn Header="Discovered Port" Binding="{Binding DiscoveredPort}" />
+                        <DataGridTextColumn Header="Discovered IP" Binding="{Binding DiscoveredIP}" />
+                        <DataGridTextColumn Header="Renewal" Binding="{Binding RenewalInterval}" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+        </TabControl>
     </Grid>
 </Window>

--- a/Kraken/MainWindow.xaml.cs
+++ b/Kraken/MainWindow.xaml.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Windows;
-using System.Management;
-using System.Runtime.InteropServices;
 
 namespace Kraken;
 
@@ -10,43 +7,12 @@ namespace Kraken;
 /// </summary>
 public partial class MainWindow : Window
 {
-    private LicenseSummary? _summary;
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MainWindow"/> class.
+    /// </summary>
     public MainWindow()
     {
         InitializeComponent();
-        DisplaySystemInfo();
-        RefreshData();
-    }
-
-    private void RefreshData()
-    {
-        _summary = LicenseService.GetLicenseSummary();
-        if (_summary != null)
-        {
-            LicensesGrid.ItemsSource = _summary.OfficeLicenses;
-        }
-    }
-
-    private void DisplaySystemInfo()
-    {
-        try
-        {
-            using var searcher = new ManagementObjectSearcher(
-                "SELECT Caption, Version, BuildNumber, OSArchitecture FROM Win32_OperatingSystem");
-            foreach (var obj in searcher.Get())
-            {
-                var caption = obj["Caption"]?.ToString()?.Trim() ?? "Windows";
-                var version = obj["Version"]?.ToString() ?? string.Empty;
-                var build = obj["BuildNumber"]?.ToString() ?? string.Empty;
-                var arch = obj["OSArchitecture"]?.ToString() ?? RuntimeInformation.OSArchitecture.ToString();
-                SystemInfoText.Text = $"{caption} Version {version} (Build {build}, {arch})";
-                break;
-            }
-        }
-        catch (ManagementException)
-        {
-            SystemInfoText.Text = $"{RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})";
-        }
+        DataContext = new MainWindowViewModel();
     }
 }

--- a/Kraken/MainWindowViewModel.cs
+++ b/Kraken/MainWindowViewModel.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Windows.Input;
+using Microsoft.Win32;
+
+namespace Kraken;
+
+/// <summary>
+/// View model for the main window.
+/// </summary>
+public class MainWindowViewModel : INotifyPropertyChanged
+{
+    private LicenseSummary _summary = new();
+
+    /// <summary>Gets or sets the licence summary.</summary>
+    public LicenseSummary Summary
+    {
+        get => _summary;
+        set
+        {
+            _summary = value;
+            OnPropertyChanged(nameof(Summary));
+            OnPropertyChanged(nameof(WindowsLicenseList));
+            OnPropertyChanged(nameof(KmsServerList));
+            OnPropertyChanged(nameof(KmsClientList));
+        }
+    }
+
+    /// <summary>Command to refresh data.</summary>
+    public ICommand RefreshCommand { get; }
+
+    /// <summary>Command to save JSON report.</summary>
+    public ICommand SaveJsonCommand { get; }
+
+    /// <summary>Information about the system.</summary>
+    public string SystemInfo { get; }
+
+    /// <summary>Collection for DataGrid binding.</summary>
+    public IEnumerable<WindowsLicenseInfo> WindowsLicenseList =>
+        Summary.WindowsLicense != null ? new[] { Summary.WindowsLicense } : Array.Empty<WindowsLicenseInfo>();
+
+    /// <summary>Collection for DataGrid binding.</summary>
+    public IEnumerable<KmsServerInfo> KmsServerList =>
+        Summary.KmsServer != null ? new[] { Summary.KmsServer } : Array.Empty<KmsServerInfo>();
+
+    /// <summary>Collection for DataGrid binding.</summary>
+    public IEnumerable<KmsClientInfo> KmsClientList =>
+        Summary.KmsClient != null ? new[] { Summary.KmsClient } : Array.Empty<KmsClientInfo>();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MainWindowViewModel"/> class.
+    /// </summary>
+    public MainWindowViewModel()
+    {
+        RefreshCommand = new RelayCommand(_ => Refresh());
+        SaveJsonCommand = new RelayCommand(_ => SaveJson(), _ => Summary != null);
+        SystemInfo = BuildSystemInfo();
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        try
+        {
+            Summary = LicenseService.GetLicenseSummary();
+        }
+        catch
+        {
+            Summary = new LicenseSummary();
+        }
+    }
+
+    private void SaveJson()
+    {
+        try
+        {
+            var dlg = new SaveFileDialog { Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*" };
+            if (dlg.ShowDialog() == true)
+            {
+                var options = new JsonSerializerOptions { WriteIndented = true };
+                var json = JsonSerializer.Serialize(Summary, options);
+                File.WriteAllText(dlg.FileName, json);
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    private string BuildSystemInfo()
+    {
+        string os = RuntimeInformation.OSDescription + " (" + RuntimeInformation.OSArchitecture + ")";
+        string ps = GetPowerShellVersion();
+        return os + " - PowerShell " + ps;
+    }
+
+    private string GetPowerShellVersion()
+    {
+        try
+        {
+            return Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine", "PowerShellVersion", "Unknown")?.ToString() ?? "Unknown";
+        }
+        catch
+        {
+            return "Unknown";
+        }
+    }
+
+    /// <inheritdoc />
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged(string name) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/Kraken/Models.cs
+++ b/Kraken/Models.cs
@@ -14,6 +14,16 @@ public class WindowsLicenseInfo
     public int GraceMinutes { get; set; }
     public DateTime? Expiration { get; set; }
     public string PartialProductKey { get; set; } = string.Empty;
+    public string Channel { get; set; } = string.Empty;
+    public DateTime? EvaluationEndDate { get; set; }
+    public DateTime? LastActivationTime { get; set; }
+    public int LastActivationHResult { get; set; }
+    public DateTime? KernelTimeBomb { get; set; }
+    public DateTime? SystemTimeBomb { get; set; }
+    public DateTime? TrustedTime { get; set; }
+    public int RearmCount { get; set; }
+    public bool IsDigitalLicense { get; set; }
+    public List<string> LicenseKeyFiles { get; set; } = new();
 }
 
 public class OfficeLicenseInfo

--- a/Kraken/RelayCommand.cs
+++ b/Kraken/RelayCommand.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Windows.Input;
+
+namespace Kraken;
+
+/// <summary>
+/// Simple ICommand implementation used for binding buttons.
+/// </summary>
+public class RelayCommand : ICommand
+{
+    private readonly Action<object?> _execute;
+    private readonly Predicate<object?>? _canExecute;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RelayCommand"/> class.
+    /// </summary>
+    public RelayCommand(Action<object?> execute, Predicate<object?>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    /// <inheritdoc />
+    public bool CanExecute(object? parameter) => _canExecute == null || _canExecute(parameter);
+
+    /// <inheritdoc />
+    public void Execute(object? parameter) => _execute(parameter);
+
+    /// <inheritdoc />
+    public event EventHandler? CanExecuteChanged;
+
+    /// <summary>
+    /// Raises the CanExecuteChanged event.
+    /// </summary>
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Kraken
 
-WPF application that queries Windows and Office licence information using the Software Protection Platform (SPP) APIs.
+WPF application that queries Windows, Office and related licence information using the Software Protection Platform (SPP) APIs.
+
+## Prerequisites
+
+- Windows 10/11
+- .NET 8 SDK or later
+- Administrator privileges may be required to read some registry keys
 
 ## Build
 
@@ -14,4 +20,4 @@ dotnet build Kraken/Kraken.csproj
 dotnet run --project Kraken/Kraken.csproj
 ```
 
-The application displays licence data in a grid.
+The application displays licence data and allows exporting the summary to JSON using the **Save JSON** button.


### PR DESCRIPTION
## Summary
- expand model classes with additional licensing fields
- add SPP API helpers and structs to wrap native calls
- implement service/view model and UI to display Windows, Office and KMS licensing data

## Testing
- `dotnet build Kraken/Kraken.csproj` *(fails: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b14f287a648326a808517ead024182