### PR TITLE
Remove refresh and JSON features

### DIFF
--- a/Kraken/MainWindow.xaml
+++ b/Kraken/MainWindow.xaml
@@ -9,15 +9,10 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <TextBlock Margin="5" Text="{Binding SystemInfo}" />
-        <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="5">
-            <Button Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,5,0" />
-            <Button Content="Save JSON" Command="{Binding SaveJsonCommand}" />
-        </StackPanel>
-        <TabControl Grid.Row="2">
+        <TabControl Grid.Row="1">
             <TabItem Header="Windows">
                 <DataGrid ItemsSource="{Binding WindowsLicenseList}" AutoGenerateColumns="False">
                     <DataGrid.Columns>

--- a/Kraken/MainWindowViewModel.cs
+++ b/Kraken/MainWindowViewModel.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using System.Runtime.InteropServices;
-using System.Text.Json;
-using System.Windows.Input;
 using Microsoft.Win32;
 
 namespace Kraken;
@@ -30,12 +27,6 @@ public class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
-    /// <summary>Command to refresh data.</summary>
-    public ICommand RefreshCommand { get; }
-
-    /// <summary>Command to save JSON report.</summary>
-    public ICommand SaveJsonCommand { get; }
-
     /// <summary>Information about the system.</summary>
     public string SystemInfo { get; }
 
@@ -56,8 +47,6 @@ public class MainWindowViewModel : INotifyPropertyChanged
     /// </summary>
     public MainWindowViewModel()
     {
-        RefreshCommand = new RelayCommand(_ => Refresh());
-        SaveJsonCommand = new RelayCommand(_ => SaveJson(), _ => Summary != null);
         SystemInfo = BuildSystemInfo();
         Refresh();
     }
@@ -74,23 +63,6 @@ public class MainWindowViewModel : INotifyPropertyChanged
         }
     }
 
-    private void SaveJson()
-    {
-        try
-        {
-            var dlg = new SaveFileDialog { Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*" };
-            if (dlg.ShowDialog() == true)
-            {
-                var options = new JsonSerializerOptions { WriteIndented = true };
-                var json = JsonSerializer.Serialize(Summary, options);
-                File.WriteAllText(dlg.FileName, json);
-            }
-        }
-        catch
-        {
-            // ignore
-        }
-    }
 
     private string BuildSystemInfo()
     {


### PR DESCRIPTION
## Summary
- Remove Refresh and Save JSON commands to make the report appear immediately on startup.
- Drop button row from the main window so the UI only displays system info and report tabs.

## Testing
- `dotnet build Kraken.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b153e67be08326903c8b9d23e8a099