### PR TITLE
refactor: use enum for license status

### DIFF
--- a/Kraken/LicenseService.cs
+++ b/Kraken/LicenseService.cs
@@ -61,7 +61,7 @@ public static class LicenseService
                     ProductName = obj["Name"]?.ToString() ?? string.Empty,
                     Description = obj["Description"]?.ToString() ?? string.Empty,
                     PartialProductKey = obj["PartialProductKey"]?.ToString() ?? string.Empty,
-                    Status = LicenseStatusToString(obj["LicenseStatus"]),
+                    Status = ParseLicenseStatus(obj["LicenseStatus"]),
                     GraceMinutes = obj["GracePeriodRemaining"] != null ? Convert.ToInt32(obj["GracePeriodRemaining"]) : 0,
                     Expiration = ParseDate(obj["EvaluationEndDate"]),
                     Channel = obj["ProductKeyChannel"]?.ToString() ?? string.Empty,
@@ -135,7 +135,7 @@ public static class LicenseService
                     ProductName = obj["Name"]?.ToString() ?? string.Empty,
                     Description = obj["Description"]?.ToString() ?? string.Empty,
                     PartialProductKey = obj["PartialProductKey"]?.ToString() ?? string.Empty,
-                    Status = LicenseStatusToString(obj["LicenseStatus"]),
+                    Status = ParseLicenseStatus(obj["LicenseStatus"]),
                     GraceMinutes = obj["GracePeriodRemaining"] != null ? Convert.ToInt32(obj["GracePeriodRemaining"]) : 0,
                     Expiration = ParseDate(obj["EvaluationEndDate"]),
                     Channel = obj["ProductKeyChannel"]?.ToString() ?? string.Empty,
@@ -399,20 +399,27 @@ public static class LicenseService
         return false;
     }
 
-    private static string LicenseStatusToString(object? statusObj)
+    private static LicenseStatus ParseLicenseStatus(object? statusObj)
     {
-        if (statusObj == null) return string.Empty;
-        int status = Convert.ToInt32(statusObj);
-        return status switch
+        if (statusObj == null) return LicenseStatus.Unknown;
+        try
         {
-            0 => "Unlicensed",
-            1 => "Licensed",
-            2 => "Grace",
-            3 => "Notification",
-            4 => "Expired",
-            5 => "Extended Grace",
-            _ => "Unknown"
-        };
+            var status = Convert.ToInt32(statusObj);
+            return status switch
+            {
+                0 => LicenseStatus.Unlicensed,
+                1 => LicenseStatus.Licensed,
+                2 => LicenseStatus.Grace,
+                3 => LicenseStatus.Notification,
+                4 => LicenseStatus.Expired,
+                5 => LicenseStatus.ExtendedGrace,
+                _ => LicenseStatus.Unknown
+            };
+        }
+        catch
+        {
+            return LicenseStatus.Unknown;
+        }
     }
 
     private static DateTime? ParseDate(object? obj)

--- a/Kraken/Models.cs
+++ b/Kraken/Models.cs
@@ -4,13 +4,34 @@ using System.Collections.Generic;
 namespace Kraken;
 
 /// <summary>
-/// POCO models representing various SPP license information blocks.
+/// Licensing state values returned by SPP.
+/// </summary>
+public enum LicenseStatus
+{
+    /// <summary>The licence state could not be determined.</summary>
+    Unknown = -1,
+    /// <summary>The product is not licensed.</summary>
+    Unlicensed = 0,
+    /// <summary>The product is permanently licensed.</summary>
+    Licensed = 1,
+    /// <summary>The product is in the initial grace period.</summary>
+    Grace = 2,
+    /// <summary>The product is in notification mode.</summary>
+    Notification = 3,
+    /// <summary>The product licence has expired.</summary>
+    Expired = 4,
+    /// <summary>The product is in extended grace.</summary>
+    ExtendedGrace = 5
+}
+
+/// <summary>
+/// POCO models representing various SPP licence information blocks.
 /// </summary>
 public class WindowsLicenseInfo
 {
     public string ProductName { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
-    public string Status { get; set; } = string.Empty;
+    public LicenseStatus Status { get; set; } = LicenseStatus.Unknown;
     public int GraceMinutes { get; set; }
     public DateTime? Expiration { get; set; }
     public string PartialProductKey { get; set; } = string.Empty;
@@ -33,7 +54,7 @@ public class OfficeLicenseInfo
     public string SkuId { get; set; } = string.Empty;
     public string ProductName { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
-    public string Status { get; set; } = string.Empty;
+    public LicenseStatus Status { get; set; } = LicenseStatus.Unknown;
     public int GraceMinutes { get; set; }
     public DateTime? Expiration { get; set; }
     public string PartialProductKey { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- introduce `LicenseStatus` enum
- use enum in Windows and Office license models
- parse license status values via helper

## Testing
- `dotnet build Kraken.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b164723f608326876d160c3071e70a