### PR TITLE
Add subscription status fields

### DIFF
--- a/Kraken/SppApi.cs
+++ b/Kraken/SppApi.cs
@@ -534,7 +534,8 @@ namespace Kraken
             public uint dwEnabled;
             public uint dwSku;
             public uint dwState;
-            // Intentionally only the fields present in the PS script.
+            public uint dwLicenseExpiration;
+            public uint dwSubscriptionType;
         }
 
         [DllImport("clipc.dll", CharSet = CharSet.Unicode)]


### PR DESCRIPTION
## Summary
- include license expiration and subscription type fields in SubStatus to support subscription info retrieval

## Testing
- `dotnet build Kraken/Kraken.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b180f1f2088326ad82716394b0116b