### PR TITLE
Add Windows offline installation ID retrieval

### DIFF
--- a/Kraken/MainWindow.xaml
+++ b/Kraken/MainWindow.xaml
@@ -18,10 +18,12 @@
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="ProductName" Binding="{Binding ProductName}" />
                         <DataGridTextColumn Header="Description" Binding="{Binding Description}" />
+                        <DataGridTextColumn Header="SkuId" Binding="{Binding SkuId}" />
                         <DataGridTextColumn Header="Status" Binding="{Binding Status}" />
                         <DataGridTextColumn Header="GraceMinutes" Binding="{Binding GraceMinutes}" />
                         <DataGridTextColumn Header="Expiration" Binding="{Binding Expiration}" />
                         <DataGridTextColumn Header="PartialProductKey" Binding="{Binding PartialProductKey}" />
+                        <DataGridTextColumn Header="OfflineInstallationId" Binding="{Binding OfflineInstallationId}" />
                         <DataGridTextColumn Header="Channel" Binding="{Binding Channel}" />
                         <DataGridTextColumn Header="EvaluationEndDate" Binding="{Binding EvaluationEndDate}" />
                         <DataGridTextColumn Header="LastActivationTime" Binding="{Binding LastActivationTime}" />

--- a/Kraken/Models.cs
+++ b/Kraken/Models.cs
@@ -31,10 +31,12 @@ public class WindowsLicenseInfo
 {
     public string ProductName { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+    public string SkuId { get; set; } = string.Empty;
     public LicenseStatus Status { get; set; } = LicenseStatus.Unknown;
     public int GraceMinutes { get; set; }
     public DateTime? Expiration { get; set; }
     public string PartialProductKey { get; set; } = string.Empty;
+    public string OfflineInstallationId { get; set; } = string.Empty;
     public string Channel { get; set; } = string.Empty;
     public DateTime? EvaluationEndDate { get; set; }
     public DateTime? LastActivationTime { get; set; }


### PR DESCRIPTION
## Summary
- capture Windows SKU identifier and generate its offline installation ID via SPP
- surface new values in UI

## Testing
- `dotnet test Kraken.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d1dbd59083269abfbe9bcfbff271