### PR TITLE
Add .NET SDK for Software Protection Platform

### DIFF
--- a/Kraken.SppSdk/ISppService.cs
+++ b/Kraken.SppSdk/ISppService.cs
@@ -1,0 +1,24 @@
+namespace Kraken.SppSdk;
+
+public interface ISppService
+{
+    Task<ISppSession> OpenSessionAsync(CancellationToken ct = default);
+    Task<WindowsLicenseInfo> GetWindowsLicenseAsync(CancellationToken ct = default);
+    Task<IReadOnlyCollection<OfficeLicenseInfo>> GetOfficeLicensesAsync(CancellationToken ct = default);
+    Task<SppLicenseStatus[]> GetLicensingStatusAsync(Guid appId, Guid skuId, CancellationToken ct = default);
+    Task<string?> GetApplicationInfoAsync(Guid appId, string name, CancellationToken ct = default);
+    Task<IReadOnlyCollection<VNextLicense>> GetVNextLicensesAsync(CancellationToken ct = default);
+    Task<SubStatus> GetSubscriptionStatusAsync(CancellationToken ct = default);
+    Task EnsureSppServiceRunningAsync(CancellationToken ct = default);
+}
+
+public interface ISppSession : IAsyncDisposable
+{
+    Task<WindowsLicenseInfo> GetWindowsLicenseAsync(CancellationToken ct = default);
+    Task<IReadOnlyCollection<OfficeLicenseInfo>> GetOfficeLicensesAsync(CancellationToken ct = default);
+    Task<SppLicenseStatus[]> GetLicensingStatusAsync(Guid appId, Guid skuId, CancellationToken ct = default);
+    Task<string?> GetApplicationInfoAsync(Guid appId, string name, CancellationToken ct = default);
+    Task<IReadOnlyCollection<VNextLicense>> GetVNextLicensesAsync(CancellationToken ct = default);
+    Task<SubStatus> GetSubscriptionStatusAsync(CancellationToken ct = default);
+    Task EnsureSppServiceRunningAsync(CancellationToken ct = default);
+}

--- a/Kraken.SppSdk/Kraken.SppSdk.csproj
+++ b/Kraken.SppSdk/Kraken.SppSdk.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/Kraken.SppSdk/Models.cs
+++ b/Kraken.SppSdk/Models.cs
@@ -1,0 +1,18 @@
+namespace Kraken.SppSdk;
+
+public enum LicenseState
+{
+    Unlicensed = 0,
+    Licensed = 1,
+    OutOfBoxGrace = 2,
+    OutOfToleranceGrace = 3,
+    NonGenuineGrace = 4,
+    Notification = 5,
+    ExtendedGrace = 6
+}
+
+public record WindowsLicenseInfo(Guid Slid, string ProductKey, DateTime? Expiry, LicenseState State);
+public record OfficeLicenseInfo(Guid Slid, string ProductKey, DateTime? Expiry, LicenseState State, string Edition);
+public record VNextLicense(string FileName, string ProductReleaseId, string Status, DateTime? Expiry);
+public record SubStatus(int LicenseStatus, int LicenseState, int GenuineStatus, int GenuineState);
+public record SppLicenseStatus(uint Status, uint GraceMinutes, uint ReasonHResult, ulong ValidityFileTimeUtc);

--- a/Kraken.SppSdk/SppApi.cs
+++ b/Kraken.SppSdk/SppApi.cs
@@ -1,0 +1,343 @@
+using System.Runtime.InteropServices;
+
+namespace Kraken.SppSdk;
+
+/// <summary>
+/// P/Invoke wrapper for the Software Protection Platform (SPP).
+/// Functions are attempted first on sppc.dll and fall back to slc.dll when
+/// sppc.dll is not available.
+/// </summary>
+public static class SppApi
+{
+    private const int E_MOD_NOT_FOUND = unchecked((int)0x8007007E);
+    private const int E_PROC_NOT_FOUND = unchecked((int)0x8007007F);
+
+    // ---------------- Safe handle ----------------
+    public sealed class SppSafeHandle : SafeHandle
+    {
+        public SppSafeHandle() : base(IntPtr.Zero, ownsHandle: true) { }
+        public override bool IsInvalid => handle == IntPtr.Zero;
+        internal void Initialize(IntPtr h) => SetHandle(h);
+
+        protected override bool ReleaseHandle()
+        {
+            try
+            {
+                try { NativeSppc.SLClose(handle); }
+                catch (DllNotFoundException) { NativeSlc.SLClose(handle); }
+                catch (EntryPointNotFoundException) { NativeSlc.SLClose(handle); }
+            }
+            catch { /* ignore */ }
+            return true;
+        }
+    }
+
+    // ---------------- Session ----------------
+    public static int SLOpen(out SppSafeHandle hSLC)
+    {
+        hSLC = new SppSafeHandle();
+        IntPtr tmp = IntPtr.Zero;
+        int hr;
+        try { hr = NativeSppc.SLOpen(ref tmp); }
+        catch (DllNotFoundException) { hr = TryOpenSlc(ref tmp); }
+        catch (EntryPointNotFoundException) { hr = TryOpenSlc(ref tmp); }
+        if (hr == 0 && tmp != IntPtr.Zero) hSLC.Initialize(tmp);
+        return hr;
+
+        static int TryOpenSlc(ref IntPtr h)
+        {
+            try { return NativeSlc.SLOpen(ref h); }
+            catch (DllNotFoundException) { return E_MOD_NOT_FOUND; }
+            catch (EntryPointNotFoundException) { return E_PROC_NOT_FOUND; }
+        }
+    }
+
+    // ---------------- Core list/status APIs ----------------
+    public static int SLGetSLIDList(SppSafeHandle h, Guid appId, out IntPtr ppGuids, out uint count)
+    {
+        Ensure(h);
+        ppGuids = IntPtr.Zero; count = 0;
+        try { return NativeSppc.SLGetSLIDList(h.DangerousGetHandle(), 0, ref appId, 1, out count, out ppGuids); }
+        catch (DllNotFoundException) { return TrySlc(h, ref appId, out ppGuids, out count); }
+        catch (EntryPointNotFoundException) { return TrySlc(h, ref appId, out ppGuids, out count); }
+
+        static int TrySlc(SppSafeHandle h, ref Guid appId, out IntPtr ppGuids, out uint count)
+        {
+            IntPtr p = IntPtr.Zero; uint c = 0;
+            try
+            {
+                int hr = NativeSlc.SLGetSLIDList(h.DangerousGetHandle(), 0, ref appId, 1, out c, out p);
+                ppGuids = p; count = c; return hr;
+            }
+            catch (DllNotFoundException) { ppGuids = IntPtr.Zero; count = 0; return E_MOD_NOT_FOUND; }
+            catch (EntryPointNotFoundException) { ppGuids = IntPtr.Zero; count = 0; return E_PROC_NOT_FOUND; }
+        }
+    }
+
+    public static int SLGetLicensingStatusInformation(SppSafeHandle h, Guid appId, Guid skuId, out IntPtr ppStatus, out uint cStatus)
+    {
+        Ensure(h);
+        ppStatus = IntPtr.Zero; cStatus = 0;
+        try { return NativeSppc.SLGetLicensingStatusInformation(h.DangerousGetHandle(), ref appId, ref skuId, IntPtr.Zero, out cStatus, out ppStatus); }
+        catch (DllNotFoundException) { return TrySlc(h, ref appId, ref skuId, out ppStatus, out cStatus); }
+        catch (EntryPointNotFoundException) { return TrySlc(h, ref appId, ref skuId, out ppStatus, out cStatus); }
+
+        static int TrySlc(SppSafeHandle h, ref Guid appId, ref Guid skuId, out IntPtr ppStatus, out uint cStatus)
+        {
+            IntPtr p = IntPtr.Zero; uint c = 0;
+            try
+            {
+                int hr = NativeSlc.SLGetLicensingStatusInformation(h.DangerousGetHandle(), ref appId, ref skuId, IntPtr.Zero, out c, out p);
+                ppStatus = p; cStatus = c; return hr;
+            }
+            catch (DllNotFoundException) { ppStatus = IntPtr.Zero; cStatus = 0; return E_MOD_NOT_FOUND; }
+            catch (EntryPointNotFoundException) { ppStatus = IntPtr.Zero; cStatus = 0; return E_PROC_NOT_FOUND; }
+        }
+    }
+
+    public static int SLGetPKeyInformation(SppSafeHandle h, Guid pkeyId, string name, out uint tData, out uint cData, out IntPtr bData)
+    {
+        Ensure(h);
+        tData = 0; cData = 0; bData = IntPtr.Zero;
+        try { return NativeSppc.SLGetPKeyInformation(h.DangerousGetHandle(), ref pkeyId, name, out tData, out cData, out bData); }
+        catch (DllNotFoundException) { return TrySlc(h, ref pkeyId, name, out tData, out cData, out bData); }
+        catch (EntryPointNotFoundException) { return TrySlc(h, ref pkeyId, name, out tData, out cData, out bData); }
+
+        static int TrySlc(SppSafeHandle h, ref Guid pkeyId, string name, out uint tData, out uint cData, out IntPtr bData)
+        {
+            uint t = 0; uint c = 0; IntPtr b = IntPtr.Zero;
+            try
+            {
+                int hr = NativeSlc.SLGetPKeyInformation(h.DangerousGetHandle(), ref pkeyId, name, out t, out c, out b);
+                tData = t; cData = c; bData = b; return hr;
+            }
+            catch (DllNotFoundException) { tData = 0; cData = 0; bData = IntPtr.Zero; return E_MOD_NOT_FOUND; }
+            catch (EntryPointNotFoundException) { tData = 0; cData = 0; bData = IntPtr.Zero; return E_PROC_NOT_FOUND; }
+        }
+    }
+
+    public static int SLGetProductSkuInformation(SppSafeHandle h, Guid skuId, string name, out uint tData, out uint cData, out IntPtr bData)
+    {
+        Ensure(h);
+        tData = 0; cData = 0; bData = IntPtr.Zero;
+        try { return NativeSppc.SLGetProductSkuInformation(h.DangerousGetHandle(), ref skuId, name, out tData, out cData, out bData); }
+        catch (DllNotFoundException) { return TrySlc(h, ref skuId, name, out tData, out cData, out bData); }
+        catch (EntryPointNotFoundException) { return TrySlc(h, ref skuId, name, out tData, out cData, out bData); }
+
+        static int TrySlc(SppSafeHandle h, ref Guid skuId, string name, out uint tData, out uint cData, out IntPtr bData)
+        {
+            uint t = 0; uint c = 0; IntPtr b = IntPtr.Zero;
+            try
+            {
+                int hr = NativeSlc.SLGetProductSkuInformation(h.DangerousGetHandle(), ref skuId, name, out t, out c, out b);
+                tData = t; cData = c; bData = b; return hr;
+            }
+            catch (DllNotFoundException) { tData = 0; cData = 0; bData = IntPtr.Zero; return E_MOD_NOT_FOUND; }
+            catch (EntryPointNotFoundException) { tData = 0; cData = 0; bData = IntPtr.Zero; return E_PROC_NOT_FOUND; }
+        }
+    }
+
+    public static int SLGetServiceInformation(SppSafeHandle h, string name, out uint tData, out uint cData, out IntPtr bData)
+    {
+        Ensure(h);
+        tData = 0; cData = 0; bData = IntPtr.Zero;
+        try { return NativeSppc.SLGetServiceInformation(h.DangerousGetHandle(), name, out tData, out cData, out bData); }
+        catch (DllNotFoundException) { return TrySlc(h, name, out tData, out cData, out bData); }
+        catch (EntryPointNotFoundException) { return TrySlc(h, name, out tData, out cData, out bData); }
+
+        static int TrySlc(SppSafeHandle h, string name, out uint tData, out uint cData, out IntPtr bData)
+        {
+            uint t = 0; uint c = 0; IntPtr b = IntPtr.Zero;
+            try
+            {
+                int hr = NativeSlc.SLGetServiceInformation(h.DangerousGetHandle(), name, out t, out c, out b);
+                tData = t; cData = c; bData = b; return hr;
+            }
+            catch (DllNotFoundException) { tData = 0; cData = 0; bData = IntPtr.Zero; return E_MOD_NOT_FOUND; }
+            catch (EntryPointNotFoundException) { tData = 0; cData = 0; bData = IntPtr.Zero; return E_PROC_NOT_FOUND; }
+        }
+    }
+
+    public static int SLGetApplicationInformation(SppSafeHandle h, Guid appId, string name, out uint tData, out uint cData, out IntPtr bData)
+    {
+        Ensure(h);
+        tData = 0; cData = 0; bData = IntPtr.Zero;
+        try { return NativeSppc.SLGetApplicationInformation(h.DangerousGetHandle(), ref appId, name, out tData, out cData, out bData); }
+        catch (DllNotFoundException) { return TrySlc(h, ref appId, name, out tData, out cData, out bData); }
+        catch (EntryPointNotFoundException) { return TrySlc(h, ref appId, name, out tData, out cData, out bData); }
+
+        static int TrySlc(SppSafeHandle h, ref Guid appId, string name, out uint tData, out uint cData, out IntPtr bData)
+        {
+            uint t = 0; uint c = 0; IntPtr b = IntPtr.Zero;
+            try
+            {
+                int hr = NativeSlc.SLGetApplicationInformation(h.DangerousGetHandle(), ref appId, name, out t, out c, out b);
+                tData = t; cData = c; bData = b; return hr;
+            }
+            catch (DllNotFoundException) { tData = 0; cData = 0; bData = IntPtr.Zero; return E_MOD_NOT_FOUND; }
+            catch (EntryPointNotFoundException) { tData = 0; cData = 0; bData = IntPtr.Zero; return E_PROC_NOT_FOUND; }
+        }
+    }
+
+    public static int SLGetWindowsInformation(string name, out uint tData, out uint cData, out IntPtr bData)
+    {
+        tData = 0; cData = 0; bData = IntPtr.Zero;
+        try { return NativeSlc.SLGetWindowsInformation(name, out tData, out cData, out bData); }
+        catch (DllNotFoundException) { return E_MOD_NOT_FOUND; }
+        catch (EntryPointNotFoundException) { return E_PROC_NOT_FOUND; }
+    }
+
+    public static int SLGetWindowsInformationDWORD(string name, out uint dword)
+    {
+        dword = 0;
+        try { return NativeSlc.SLGetWindowsInformationDWORD(name, out dword); }
+        catch (DllNotFoundException) { return E_MOD_NOT_FOUND; }
+        catch (EntryPointNotFoundException) { return E_PROC_NOT_FOUND; }
+    }
+
+    public static int GenerateOfflineInstallationId(SppSafeHandle h, Guid skuId, out string? offlineId)
+    {
+        Ensure(h);
+        offlineId = null;
+        IntPtr p = IntPtr.Zero;
+        try
+        {
+            int hr;
+            try { hr = NativeSppc.SLGenerateOfflineInstallationId(h.DangerousGetHandle(), ref skuId, out p); }
+            catch (DllNotFoundException) { hr = NativeSlc.SLGenerateOfflineInstallationId(h.DangerousGetHandle(), ref skuId, out p); }
+            catch (EntryPointNotFoundException) { hr = NativeSlc.SLGenerateOfflineInstallationId(h.DangerousGetHandle(), ref skuId, out p); }
+            if (hr != 0) return hr;
+            offlineId = Marshal.PtrToStringUni(p);
+            return hr;
+        }
+        finally
+        {
+            if (p != IntPtr.Zero)
+                Marshal.FreeHGlobal(p);
+        }
+    }
+
+    // Subscription status (clipc.dll)
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RawSubStatus
+    {
+        public uint dwEnabled;
+        public uint dwSku;
+        public uint dwState;
+        public uint dwLicenseExpiration;
+        public uint dwSubscriptionType;
+    }
+
+    [DllImport("clipc.dll", CharSet = CharSet.Unicode)]
+    private static extern int ClipGetSubscriptionStatusNative(ref IntPtr pStatus);
+
+    public static int ClipGetSubscriptionStatus(out SubStatus status)
+    {
+        status = default;
+        IntPtr buf = IntPtr.Zero;
+        try
+        {
+            buf = Marshal.AllocHGlobal(Marshal.SizeOf<SubStatus>());
+            IntPtr p = buf;
+            int hr = ClipGetSubscriptionStatusNative(ref p);
+            if (hr != 0 || p == IntPtr.Zero) return hr != 0 ? hr : -1;
+            status = Marshal.PtrToStructure<SubStatus>(p);
+            return 0;
+        }
+        finally
+        {
+            if (buf != IntPtr.Zero) Marshal.FreeHGlobal(buf);
+        }
+    }
+
+    // ---------------- Helpers ----------------
+    public enum SppValueKind { Unknown = 0, String = 1, UInt32 = 4, UInt64 = 8 }
+    public readonly record struct SppValue(SppValueKind Kind, string? S, uint? U32, ulong? U64)
+    {
+        public static SppValue FromString(string s) => new(SppValueKind.String, s, null, null);
+        public static SppValue FromUInt32(uint v) => new(SppValueKind.UInt32, null, v, null);
+        public static SppValue FromUInt64(ulong v) => new(SppValueKind.UInt64, null, null, v);
+        public static readonly SppValue Empty = new(SppValueKind.Unknown, null, null, null);
+    }
+
+    public static SppValue InterpretValue(uint tData, uint cData, IntPtr bData)
+    {
+        if (tData == 1 && bData != IntPtr.Zero)
+        {
+            string s = cData > 0 ? Marshal.PtrToStringUni(bData, (int)(cData / 2))?.TrimEnd('\0') ?? string.Empty : Marshal.PtrToStringUni(bData) ?? string.Empty;
+            return SppValue.FromString(s);
+        }
+        if (tData == 4) return SppValue.FromUInt32((uint)Marshal.ReadInt32(bData));
+        if (tData == 8) return SppValue.FromUInt64((ulong)Marshal.ReadInt64(bData));
+        return SppValue.Empty;
+    }
+
+    public static SppLicenseStatus[] ParseLicensingStatus(IntPtr pStatus, uint count)
+    {
+        if (pStatus == IntPtr.Zero || count == 0) return Array.Empty<SppLicenseStatus>();
+        var arr = new SppLicenseStatus[count];
+        const int stride = 40;
+        for (uint i = 0; i < count; i++)
+        {
+            IntPtr entry = IntPtr.Add(pStatus, (int)(i * stride));
+            uint status = (uint)Marshal.ReadInt32(entry, 16);
+            uint grace = (uint)Marshal.ReadInt32(entry, 20);
+            uint reason = (uint)Marshal.ReadInt32(entry, 28);
+            ulong valid = (ulong)(long)Marshal.ReadInt64(entry, 32);
+            if (status == 3) status = 5;
+            if (status == 2)
+            {
+                if (reason == 0x4004F00D) status = 3;
+                else if (reason == 0x4004F065) status = 4;
+                else if (reason == 0x4004FC06) status = 6;
+            }
+            arr[i] = new SppLicenseStatus(status, grace, reason, valid);
+        }
+        return arr;
+    }
+
+    private static void Ensure(SppSafeHandle h)
+    {
+        if (h is null || h.IsInvalid)
+            throw new ArgumentException("Invalid SPP handle.", nameof(h));
+    }
+
+    // ---------------- Native imports ----------------
+    internal static class NativeSppc
+    {
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLOpen(ref IntPtr hSLC);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLClose(IntPtr hSLC);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetSLIDList(IntPtr hSLC, uint dwFlags, ref Guid appId, uint dwCount, out uint pcSLIDs, out IntPtr ppSLIDs);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetLicensingStatusInformation(IntPtr hSLC, ref Guid appId, ref Guid skuId, IntPtr pwszProductVersion, out uint pcStatus, out IntPtr ppStatus);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetPKeyInformation(IntPtr hSLC, ref Guid pkeyId, string valueName, out uint tData, out uint cData, out IntPtr bData);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetProductSkuInformation(IntPtr hSLC, ref Guid skuId, string valueName, out uint tData, out uint cData, out IntPtr bData);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetServiceInformation(IntPtr hSLC, string valueName, out uint tData, out uint cData, out IntPtr bData);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetApplicationInformation(IntPtr hSLC, ref Guid appId, string valueName, out uint tData, out uint cData, out IntPtr bData);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGenerateOfflineInstallationId(IntPtr hSLC, ref Guid skuId, out IntPtr pwszOfflineId);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLSetLicensingStatusInformation(IntPtr hSLC, ref Guid appId, ref Guid skuId, string valueName, uint tData, uint cData, IntPtr bData);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLSetApplicationInformation(IntPtr hSLC, ref Guid appId, string valueName, uint tData, uint cData, IntPtr bData);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLSetServiceInformation(IntPtr hSLC, string valueName, uint tData, uint cData, IntPtr bData);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLSetPKeyInformation(IntPtr hSLC, ref Guid pkeyId, string valueName, uint tData, uint cData, IntPtr bData);
+        [DllImport("sppc.dll", CharSet = CharSet.Unicode)] internal static extern int SLSetProductSkuInformation(IntPtr hSLC, ref Guid skuId, string valueName, uint tData, uint cData, IntPtr bData);
+    }
+
+    internal static class NativeSlc
+    {
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLOpen(ref IntPtr hSLC);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLClose(IntPtr hSLC);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetSLIDList(IntPtr hSLC, uint dwFlags, ref Guid appId, uint dwCount, out uint pcSLIDs, out IntPtr ppSLIDs);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetLicensingStatusInformation(IntPtr hSLC, ref Guid appId, ref Guid skuId, IntPtr pwszProductVersion, out uint pcStatus, out IntPtr ppStatus);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetPKeyInformation(IntPtr hSLC, ref Guid pkeyId, string valueName, out uint tData, out uint cData, out IntPtr bData);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetProductSkuInformation(IntPtr hSLC, ref Guid skuId, string valueName, out uint tData, out uint cData, out IntPtr bData);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetServiceInformation(IntPtr hSLC, string valueName, out uint tData, out uint cData, out IntPtr bData);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetApplicationInformation(IntPtr hSLC, ref Guid appId, string valueName, out uint tData, out uint cData, out IntPtr bData);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGenerateOfflineInstallationId(IntPtr hSLC, ref Guid skuId, out IntPtr pwszOfflineId);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetWindowsInformation(string valueName, out uint tData, out uint cData, out IntPtr bData);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLGetWindowsInformationDWORD(string valueName, out uint dword);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLSetLicensingStatusInformation(IntPtr hSLC, ref Guid appId, ref Guid skuId, string valueName, uint tData, uint cData, IntPtr bData);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLSetApplicationInformation(IntPtr hSLC, ref Guid appId, string valueName, uint tData, uint cData, IntPtr bData);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLSetServiceInformation(IntPtr hSLC, string valueName, uint tData, uint cData, IntPtr bData);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLSetPKeyInformation(IntPtr hSLC, ref Guid pkeyId, string valueName, uint tData, uint cData, IntPtr bData);
+        [DllImport("slc.dll", CharSet = CharSet.Unicode)] internal static extern int SLSetProductSkuInformation(IntPtr hSLC, ref Guid skuId, string valueName, uint tData, uint cData, IntPtr bData);
+    }
+}

--- a/Kraken.SppSdk/SppException.cs
+++ b/Kraken.SppSdk/SppException.cs
@@ -1,0 +1,13 @@
+namespace Kraken.SppSdk;
+
+public sealed class SppException : Exception
+{
+    public int HResultCode { get; }
+    public string? Function { get; }
+
+    public SppException(int hresult, string? function = null) : base($"SPP call failed with HRESULT 0x{hresult:X8}" + (function != null ? $" in {function}" : string.Empty))
+    {
+        HResultCode = hresult;
+        Function = function;
+    }
+}

--- a/Kraken.SppSdk/SppService.cs
+++ b/Kraken.SppSdk/SppService.cs
@@ -1,0 +1,85 @@
+using Serilog;
+
+namespace Kraken.SppSdk;
+
+public sealed class SppService : ISppService
+{
+    private readonly ILogger _logger;
+
+    public SppService(ILogger logger) => _logger = logger;
+
+    public async Task<ISppSession> OpenSessionAsync(CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(OpenSessionAsync));
+        var handle = await Task.Run(() =>
+        {
+            int hr = SppApi.SLOpen(out var h);
+            if (hr != 0) throw new SppException(hr, nameof(SppApi.SLOpen));
+            return h;
+        }, ct);
+        _logger.Debug("Exiting {Method}", nameof(OpenSessionAsync));
+        return new SppSession(handle, _logger);
+    }
+
+    public async Task<WindowsLicenseInfo> GetWindowsLicenseAsync(CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetWindowsLicenseAsync));
+        await using var session = await OpenSessionAsync(ct);
+        var result = await session.GetWindowsLicenseAsync(ct);
+        _logger.Debug("Exiting {Method}", nameof(GetWindowsLicenseAsync));
+        return result;
+    }
+
+    public async Task<IReadOnlyCollection<OfficeLicenseInfo>> GetOfficeLicensesAsync(CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetOfficeLicensesAsync));
+        await using var session = await OpenSessionAsync(ct);
+        var result = await session.GetOfficeLicensesAsync(ct);
+        _logger.Debug("Exiting {Method}", nameof(GetOfficeLicensesAsync));
+        return result;
+    }
+
+    public async Task<SppLicenseStatus[]> GetLicensingStatusAsync(Guid appId, Guid skuId, CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetLicensingStatusAsync));
+        await using var session = await OpenSessionAsync(ct);
+        var result = await session.GetLicensingStatusAsync(appId, skuId, ct);
+        _logger.Debug("Exiting {Method}", nameof(GetLicensingStatusAsync));
+        return result;
+    }
+
+    public async Task<string?> GetApplicationInfoAsync(Guid appId, string name, CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetApplicationInfoAsync));
+        await using var session = await OpenSessionAsync(ct);
+        var result = await session.GetApplicationInfoAsync(appId, name, ct);
+        _logger.Debug("Exiting {Method}", nameof(GetApplicationInfoAsync));
+        return result;
+    }
+
+    public async Task<IReadOnlyCollection<VNextLicense>> GetVNextLicensesAsync(CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetVNextLicensesAsync));
+        await using var session = await OpenSessionAsync(ct);
+        var result = await session.GetVNextLicensesAsync(ct);
+        _logger.Debug("Exiting {Method}", nameof(GetVNextLicensesAsync));
+        return result;
+    }
+
+    public async Task<SubStatus> GetSubscriptionStatusAsync(CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetSubscriptionStatusAsync));
+        await using var session = await OpenSessionAsync(ct);
+        var result = await session.GetSubscriptionStatusAsync(ct);
+        _logger.Debug("Exiting {Method}", nameof(GetSubscriptionStatusAsync));
+        return result;
+    }
+
+    public async Task EnsureSppServiceRunningAsync(CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(EnsureSppServiceRunningAsync));
+        await using var session = await OpenSessionAsync(ct);
+        await session.EnsureSppServiceRunningAsync(ct);
+        _logger.Debug("Exiting {Method}", nameof(EnsureSppServiceRunningAsync));
+    }
+}

--- a/Kraken.SppSdk/SppSession.cs
+++ b/Kraken.SppSdk/SppSession.cs
@@ -1,0 +1,203 @@
+using System.Runtime.InteropServices;
+using System.ServiceProcess;
+using System.Text.Json;
+using Microsoft.Win32;
+using Serilog;
+
+namespace Kraken.SppSdk;
+
+internal sealed class SppSession : ISppSession
+{
+    private readonly SppApi.SppSafeHandle _handle;
+    private readonly ILogger _logger;
+
+    internal SppSession(SppApi.SppSafeHandle handle, ILogger logger)
+    {
+        _handle = handle;
+        _logger = logger;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _handle.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private static void ThrowIfFailed(int hr, string function) => throw new SppException(hr, function);
+
+    private IReadOnlyCollection<Guid> GetSlids(Guid appId)
+    {
+        int hr = SppApi.SLGetSLIDList(_handle, appId, out var pGuids, out var count);
+        if (hr != 0) ThrowIfFailed(hr, nameof(SppApi.SLGetSLIDList));
+        try
+        {
+            var guids = new Guid[count];
+            int size = Marshal.SizeOf<Guid>();
+            for (int i = 0; i < count; i++)
+            {
+                IntPtr ptr = IntPtr.Add(pGuids, i * size);
+                guids[i] = Marshal.PtrToStructure<Guid>(ptr);
+            }
+            return guids;
+        }
+        finally
+        {
+            if (pGuids != IntPtr.Zero) Marshal.FreeHGlobal(pGuids);
+        }
+    }
+
+    private string GetProductKey(Guid slid)
+    {
+        int hr = SppApi.SLGetPKeyInformation(_handle, slid, "ProductKey", out uint t, out uint c, out IntPtr b);
+        if (hr != 0) ThrowIfFailed(hr, nameof(SppApi.SLGetPKeyInformation));
+        try { return SppApi.InterpretValue(t, c, b).S ?? string.Empty; }
+        finally { if (b != IntPtr.Zero) Marshal.FreeHGlobal(b); }
+    }
+
+    private string GetProductSkuString(Guid skuId, string name)
+    {
+        int hr = SppApi.SLGetProductSkuInformation(_handle, skuId, name, out uint t, out uint c, out IntPtr b);
+        if (hr != 0) ThrowIfFailed(hr, nameof(SppApi.SLGetProductSkuInformation));
+        try { return SppApi.InterpretValue(t, c, b).S ?? string.Empty; }
+        finally { if (b != IntPtr.Zero) Marshal.FreeHGlobal(b); }
+    }
+
+    private SppLicenseStatus[] GetLicensingStatus(Guid appId, Guid skuId)
+    {
+        int hr = SppApi.SLGetLicensingStatusInformation(_handle, appId, skuId, out IntPtr p, out uint c);
+        if (hr != 0) ThrowIfFailed(hr, nameof(SppApi.SLGetLicensingStatusInformation));
+        try { return SppApi.ParseLicensingStatus(p, c); }
+        finally { if (p != IntPtr.Zero) Marshal.FreeHGlobal(p); }
+    }
+
+    public Task<WindowsLicenseInfo> GetWindowsLicenseAsync(CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetWindowsLicenseAsync));
+        return Task.Run(() =>
+        {
+            var appId = new Guid("55C92734-D682-4D71-983E-D6EC3F16059F");
+            foreach (var slid in GetSlids(appId))
+            {
+                var key = GetProductKey(slid);
+                var status = GetLicensingStatus(appId, slid);
+                DateTime? expiry = status.Length > 0 && status[0].ValidityFileTimeUtc != 0 ? DateTime.FromFileTimeUtc((long)status[0].ValidityFileTimeUtc) : null;
+                var state = status.Length > 0 ? (LicenseState)status[0].Status : LicenseState.Unlicensed;
+                var info = new WindowsLicenseInfo(slid, key, expiry, state);
+                _logger.Debug("Exiting {Method}", nameof(GetWindowsLicenseAsync));
+                return info;
+            }
+            _logger.Debug("Exiting {Method}", nameof(GetWindowsLicenseAsync));
+            return new WindowsLicenseInfo(Guid.Empty, string.Empty, null, LicenseState.Unlicensed);
+        }, ct);
+    }
+
+    public Task<IReadOnlyCollection<OfficeLicenseInfo>> GetOfficeLicensesAsync(CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetOfficeLicensesAsync));
+        return Task.Run(() =>
+        {
+            var appId = new Guid("0FF1CE15-A989-479D-AF46-F275C6370663");
+            var list = new List<OfficeLicenseInfo>();
+            foreach (var slid in GetSlids(appId))
+            {
+                var key = GetProductKey(slid);
+                var status = GetLicensingStatus(appId, slid);
+                DateTime? expiry = status.Length > 0 && status[0].ValidityFileTimeUtc != 0 ? DateTime.FromFileTimeUtc((long)status[0].ValidityFileTimeUtc) : null;
+                var state = status.Length > 0 ? (LicenseState)status[0].Status : LicenseState.Unlicensed;
+                string edition = string.Empty;
+                try { edition = GetProductSkuString(slid, "Name"); } catch { }
+                list.Add(new OfficeLicenseInfo(slid, key, expiry, state, edition));
+            }
+            _logger.Debug("Exiting {Method}", nameof(GetOfficeLicensesAsync));
+            return (IReadOnlyCollection<OfficeLicenseInfo>)list;
+        }, ct);
+    }
+
+    public Task<SppLicenseStatus[]> GetLicensingStatusAsync(Guid appId, Guid skuId, CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetLicensingStatusAsync));
+        return Task.Run(() =>
+        {
+            var status = GetLicensingStatus(appId, skuId);
+            _logger.Debug("Exiting {Method}", nameof(GetLicensingStatusAsync));
+            return status;
+        }, ct);
+    }
+
+    public Task<string?> GetApplicationInfoAsync(Guid appId, string name, CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetApplicationInfoAsync));
+        return Task.Run(() =>
+        {
+            int hr = SppApi.SLGetApplicationInformation(_handle, appId, name, out uint t, out uint c, out IntPtr b);
+            if (hr != 0) ThrowIfFailed(hr, nameof(SppApi.SLGetApplicationInformation));
+            try { return SppApi.InterpretValue(t, c, b).S; }
+            finally { if (b != IntPtr.Zero) Marshal.FreeHGlobal(b); _logger.Debug("Exiting {Method}", nameof(GetApplicationInfoAsync)); }
+        }, ct);
+    }
+
+    public Task<IReadOnlyCollection<VNextLicense>> GetVNextLicensesAsync(CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetVNextLicensesAsync));
+        return Task.Run(() =>
+        {
+            var list = new List<VNextLicense>();
+            using var office = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\\Microsoft\\Office");
+            if (office != null)
+            {
+                string baseDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "Office", "Licenses");
+                foreach (var ver in office.GetSubKeyNames())
+                {
+                    using var key = office.OpenSubKey($"{ver}\\Common\\Licensing\\LicensingNext");
+                    if (key == null) continue;
+                    foreach (var sub in key.GetSubKeyNames())
+                    {
+                        string file = Path.Combine(baseDir, sub + ".json");
+                        if (!File.Exists(file)) continue;
+                        string encoded = File.ReadAllText(file);
+                        var data = Convert.FromBase64String(encoded);
+                        using var doc = JsonDocument.Parse(data);
+                        string release = doc.RootElement.GetProperty("ProductReleaseId").GetString() ?? string.Empty;
+                        string status = doc.RootElement.GetProperty("Status").GetString() ?? string.Empty;
+                        DateTime? expiry = null;
+                        if (doc.RootElement.TryGetProperty("Expiry", out var ex))
+                        {
+                            if (ex.ValueKind == JsonValueKind.String && DateTime.TryParse(ex.GetString(), out var dt)) expiry = dt;
+                            else if (ex.ValueKind == JsonValueKind.Number) expiry = DateTimeOffset.FromUnixTimeSeconds(ex.GetInt64()).DateTime;
+                        }
+                        list.Add(new VNextLicense(Path.GetFileName(file), release, status, expiry));
+                    }
+                }
+            }
+            _logger.Debug("Exiting {Method}", nameof(GetVNextLicensesAsync));
+            return (IReadOnlyCollection<VNextLicense>)list;
+        }, ct);
+    }
+
+    public Task<SubStatus> GetSubscriptionStatusAsync(CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(GetSubscriptionStatusAsync));
+        return Task.Run(() =>
+        {
+            int hr = SppApi.ClipGetSubscriptionStatus(out var status);
+            if (hr != 0) ThrowIfFailed(hr, nameof(SppApi.ClipGetSubscriptionStatus));
+            _logger.Debug("Exiting {Method}", nameof(GetSubscriptionStatusAsync));
+            return status;
+        }, ct);
+    }
+
+    public Task EnsureSppServiceRunningAsync(CancellationToken ct = default)
+    {
+        _logger.Debug("Entering {Method}", nameof(EnsureSppServiceRunningAsync));
+        return Task.Run(() =>
+        {
+            using var sc = new ServiceController("sppsvc");
+            if (sc.Status != ServiceControllerStatus.Running)
+            {
+                sc.Start();
+                sc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(30));
+            }
+            _logger.Debug("Exiting {Method}", nameof(EnsureSppServiceRunningAsync));
+        }, ct);
+    }
+}

--- a/Kraken.sln
+++ b/Kraken.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36408.4 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kraken", "Kraken\Kraken.csproj", "{231CBA66-6A8A-42E4-8ADC-45C53DA741E9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kraken.SppSdk", "Kraken.SppSdk\Kraken.SppSdk.csproj", "{8988E11B-7578-4DFB-97B8-F462DABCE1D4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{231CBA66-6A8A-42E4-8ADC-45C53DA741E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{231CBA66-6A8A-42E4-8ADC-45C53DA741E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{231CBA66-6A8A-42E4-8ADC-45C53DA741E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8988E11B-7578-4DFB-97B8-F462DABCE1D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8988E11B-7578-4DFB-97B8-F462DABCE1D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8988E11B-7578-4DFB-97B8-F462DABCE1D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8988E11B-7578-4DFB-97B8-F462DABCE1D4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- introduce `Kraken.SppSdk` library exposing async `ISppService` and `ISppSession`
- add P/Invoke wrapper `SppApi` with safe handle and subscription status helper
- implement `SppService`/`SppSession` with Serilog logging and DTO records

## Testing
- `dotnet build Kraken.SppSdk/Kraken.SppSdk.csproj`
- `dotnet build Kraken.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1deb50e1c8326822fd4c295575989