### PR TITLE
Add Serilog-based SPP session helpers and DI support

### DIFF
--- a/Kraken/Kraken.csproj
+++ b/Kraken/Kraken.csproj
@@ -29,6 +29,8 @@
   <ItemGroup>
     <PackageReference Include="System.Management" Version="9.0.8" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Kraken/SppDI.cs
+++ b/Kraken/SppDI.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
+namespace Kraken;
+
+/// <summary>
+/// Dependency injection helpers for registering Software Protection Platform services.
+/// </summary>
+public static class SppDI
+{
+    /// <summary>
+    /// Adds SPP session support to the service collection.
+    /// </summary>
+    public static IServiceCollection AddSpp(this IServiceCollection services)
+    {
+        services.AddSingleton<SppSession>(_ =>
+        {
+            try
+            {
+                return SppSession.Open();
+            }
+            catch (SppException ex)
+            {
+                Log.Error(ex, "Unable to open SPP session");
+                throw;
+            }
+        });
+        return services;
+    }
+}
+

--- a/Kraken/SppException.cs
+++ b/Kraken/SppException.cs
@@ -1,0 +1,28 @@
+using System;
+using Serilog;
+
+namespace Kraken;
+
+/// <summary>
+/// Represents errors that occur when interacting with the Software Protection Platform.
+/// Logs the error using Serilog upon creation.
+/// </summary>
+public class SppException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SppException"/> class with a specified error message.
+    /// </summary>
+    public SppException(string message) : base(message)
+    {
+        Log.Error(message);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SppException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    public SppException(string message, Exception innerException) : base(message, innerException)
+    {
+        Log.Error(innerException, message);
+    }
+}
+

--- a/Kraken/SppExtension.cs
+++ b/Kraken/SppExtension.cs
@@ -1,0 +1,12 @@
+namespace Kraken;
+
+/// <summary>
+/// Helper extension methods for working with <see cref="SppApi.SppValue"/> values.
+/// </summary>
+public static class SppExtension
+{
+    public static string? AsString(this SppApi.SppValue value) => value.S;
+    public static uint? AsUInt32(this SppApi.SppValue value) => value.U32;
+    public static ulong? AsUInt64(this SppApi.SppValue value) => value.U64;
+}
+

--- a/Kraken/SppSession.cs
+++ b/Kraken/SppSession.cs
@@ -1,0 +1,51 @@
+using System;
+using Serilog;
+
+namespace Kraken;
+
+/// <summary>
+/// Represents a managed Software Protection Platform session.
+/// </summary>
+public sealed class SppSession : IDisposable
+{
+    private readonly SppApi.SppSafeHandle _handle;
+    private bool _disposed;
+
+    private SppSession(SppApi.SppSafeHandle handle)
+    {
+        _handle = handle;
+    }
+
+    /// <summary>
+    /// Opens a new SPP session.
+    /// </summary>
+    /// <exception cref="SppException">Thrown when the session cannot be opened.</exception>
+    public static SppSession Open()
+    {
+        if (!SppApi.TryOpenSession(out var handle))
+        {
+            Log.Error("Failed to open SPP session");
+            throw new SppException("Cannot open SPP session.");
+        }
+
+        Log.Information("SPP session opened");
+        return new SppSession(handle);
+    }
+
+    /// <summary>
+    /// Gets the native SPP handle.
+    /// </summary>
+    public SppApi.SppSafeHandle Handle => _handle;
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _handle.Dispose();
+            _disposed = true;
+            Log.Information("SPP session closed");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `SppException` that logs with Serilog when created
- introduce `SppSession` wrapper plus extensions and DI registration helpers
- reference Serilog and Microsoft.Extensions.DependencyInjection packages

## Testing
- `dotnet test Kraken.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e137527083269c30f2abbb8bc28c